### PR TITLE
CRLF line endings and use ip instead of ifconfig

### DIFF
--- a/wsl_update_hosts.sh
+++ b/wsl_update_hosts.sh
@@ -4,7 +4,7 @@ HOST_FILE="/mnt/c/Windows/System32/drivers/etc/hosts"
 HOST_NAME="ubuntu1804.wsl"
 TAG_STR="#FKMS_AC"
 
-ETH0_IP=$(ifconfig eth0 | grep -w inet | awk '{print $2}')
+ETH0_IP=$(ip a | grep -Ew '^\s*inet.*eth0$' | awk '{print $2}' | cut -d"/" -f1)
 echo $ETH0_IP
 
 if grep -q $TAG_STR "$HOST_FILE"; then

--- a/wsl_update_hosts.sh
+++ b/wsl_update_hosts.sh
@@ -8,9 +8,9 @@ ETH0_IP=$(ip a | grep -Ew '^\s*inet.*eth0$' | awk '{print $2}' | cut -d"/" -f1)
 echo $ETH0_IP
 
 if grep -q $TAG_STR "$HOST_FILE"; then
-  #replace host if any
-  TEMP_SED=$(sed -r "s/(.*)^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}) (.*$TAG_STR)(.*)/\1$ETH0_IP \3\4/g" $HOST_FILE)
-  echo "$TEMP_SED" > $HOST_FILE
+  # replace host if any
+  TEMP_SED=$(sed -r "s/(.*)^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}) (.*$TAG_STR)(.*)\r\n/\1$ETH0_IP \3\4/g" $HOST_FILE)
+  printf "%s" "$TEMP_SED" > $HOST_FILE
 else
-  echo "\n#WSL2 host entry by acamar\n $ETH0_IP $HOST_NAME $TAG_STR" >>  $HOST_FILE
+  printf "\r\n%s\r\n%s\r\n" "# WSL2 host entry by acamar" "$ETH0_IP $HOST_NAME $TAG_STR" >>  $HOST_FILE
 fi


### PR DESCRIPTION
Just a couple of minor changes to add CRLF line endings and replace ifconfig with ip. I think ifconfig has been deprecated for years and doesn't even get installed by default on my Pengwin 12 (basically Debian) setup.